### PR TITLE
Fix CodeMirror Merge chunks typing.

### DIFF
--- a/types/codemirror/index.d.ts
+++ b/types/codemirror/index.d.ts
@@ -1239,14 +1239,14 @@ declare namespace CodeMirror {
            * Left side of the merge view.
            */
           left: DiffView;
-          leftChunks(): MergeViewDiffChunk;
+          leftChunks(): MergeViewDiffChunk[];
           leftOriginal(): Editor;
 
           /**
            * Right side of the merge view.
            */
           right: DiffView;
-          rightChunks(): MergeViewDiffChunk;
+          rightChunks(): MergeViewDiffChunk[];
           rightOriginal(): Editor;
 
           /**


### PR DESCRIPTION
leftChunks() and rightChunks() returns an array of MergeViewDiffChunk.

See https://github.com/codemirror/CodeMirror/blob/master/addon/merge/merge.js#L666